### PR TITLE
修正 UI 時間顯示為台灣時區

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       CALLMESH_ARTIFACTS_DIR: "/data/callmesh"
       CALLMESH_VERIFICATION_FILE: "/data/callmesh/monitor.json"
       TMAG_WEB_DASHBOARD: "${TMAG_WEB_DASHBOARD:-1}"
+      TMAG_TIMEZONE: "${TMAG_TIMEZONE:-Asia/Taipei}"
       TENMAN_DISABLE: "${TENMAN_DISABLE:-0}"
       AUTO_UPDATE: "${AUTO_UPDATE:-1}"
       AUTO_UPDATE_REPO: "${AUTO_UPDATE_REPO:-https://github.com/toodi0418/CMClient.git}"

--- a/docs/issue-timezone-taipei.md
+++ b/docs/issue-timezone-taipei.md
@@ -23,6 +23,9 @@
 - Mapping Flow 與 `toLocaleString()` 顯示改為固定台灣時區
 - 若需彈性，可新增 `TMAG_TIMEZONE` 設定供覆寫
 
+## 更新
+- PR #5 已補上 `TMAG_TIMEZONE` 覆寫與 UI 統一格式化（請確認是否符合需求）
+
 ## 驗收標準
 - 在 UTC 環境下顯示仍為台灣時間
 - Web / Electron 顯示時間一致

--- a/docs/pr-timezone-taipei.md
+++ b/docs/pr-timezone-taipei.md
@@ -4,10 +4,14 @@
 - 新增統一時間格式化 helper，固定 `Asia/Taipei`
 - Mapping Flow、遙測、節點與 tooltip 等顯示改用固定時區
 - Web 與 Electron 顯示時間一致
+- 支援 `TMAG_TIMEZONE` 覆寫（Docker Compose 已加入範例）
 
 ## 變更檔案
 - `src/web/public/main.js`
 - `src/electron/renderer.js`
+- `src/web/server.js`
+- `src/electron/main.js`
+- `docker-compose.yml`
 
 ## 測試
 - 未執行（僅前端時間格式化調整）

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -42,6 +42,10 @@ const { SerialPort } = require('serialport');
 const HEARTBEAT_INTERVAL_MS = 60_000;
 const MESSAGE_LOG_FILENAME = 'message-log.jsonl';
 const MESSAGE_MAX_PER_CHANNEL = 200;
+const DEFAULT_TIME_ZONE =
+  typeof process.env.TMAG_TIMEZONE === 'string' && process.env.TMAG_TIMEZONE.trim()
+    ? process.env.TMAG_TIMEZONE.trim()
+    : 'Asia/Taipei';
 
 const messageStore = new Map();
 let messageWritePromise = Promise.resolve();
@@ -874,7 +878,8 @@ function waitForInitialMeshtasticConnection(nativeClient, { timeoutMs = 15_000 }
 }
 
 ipcMain.handle('app:get-info', async () => ({
-  version: appVersion
+  version: appVersion,
+  timeZone: DEFAULT_TIME_ZONE
 }));
 
 ipcMain.handle('nodes:get-snapshot', async () => {

--- a/src/web/public/main.js
+++ b/src/web/public/main.js
@@ -119,10 +119,27 @@
   let telemetrySelectedMeshId = null;
   const telemetryNodeLookup = new Map();
   const DEFAULT_TIME_ZONE = 'Asia/Taipei';
+  let activeTimeZone = DEFAULT_TIME_ZONE;
   const DATE_TIME_FORMATTERS = new Map();
 
-  function getDateTimeFormatter(timeZone = DEFAULT_TIME_ZONE) {
-    const zone = timeZone || DEFAULT_TIME_ZONE;
+  function normalizeTimeZone(value) {
+    return typeof value === 'string' && value.trim() ? value.trim() : '';
+  }
+
+  function setActiveTimeZone(value) {
+    const normalized = normalizeTimeZone(value);
+    if (!normalized || normalized === activeTimeZone) {
+      return;
+    }
+    activeTimeZone = normalized;
+    DATE_TIME_FORMATTERS.clear();
+    renderFlowEntries();
+    updateTelemetryUpdatedAtLabel();
+    renderTelemetryView();
+  }
+
+  function getDateTimeFormatter(timeZone = activeTimeZone) {
+    const zone = timeZone || activeTimeZone;
     let formatter = DATE_TIME_FORMATTERS.get(zone);
     if (!formatter) {
       formatter = new Intl.DateTimeFormat('en-GB', {
@@ -140,7 +157,7 @@
     return formatter;
   }
 
-  function getDateTimeParts(value, timeZone = DEFAULT_TIME_ZONE) {
+  function getDateTimeParts(value, timeZone = activeTimeZone) {
     if (value == null) return null;
     const date = value instanceof Date ? value : new Date(value);
     if (Number.isNaN(date.getTime())) return null;
@@ -161,20 +178,20 @@
     };
   }
 
-  function formatTimeInZone(value, timeZone = DEFAULT_TIME_ZONE) {
+  function formatTimeInZone(value, timeZone = activeTimeZone) {
     const parts = getDateTimeParts(value, timeZone);
     if (!parts) return '—';
     return `${parts.hour}:${parts.minute}:${parts.second}`;
   }
 
-  function formatDateTimeInZone(value, { includeSeconds = true } = {}, timeZone = DEFAULT_TIME_ZONE) {
+  function formatDateTimeInZone(value, { includeSeconds = true } = {}, timeZone = activeTimeZone) {
     const parts = getDateTimeParts(value, timeZone);
     if (!parts) return '—';
     const time = includeSeconds ? `${parts.hour}:${parts.minute}:${parts.second}` : `${parts.hour}:${parts.minute}`;
     return `${parts.year}/${parts.month}/${parts.day} ${time}`;
   }
 
-  function formatMonthDayTimeInZone(value, timeZone = DEFAULT_TIME_ZONE) {
+  function formatMonthDayTimeInZone(value, timeZone = activeTimeZone) {
     const parts = getDateTimeParts(value, timeZone);
     if (!parts) return '';
     return `${parts.month}/${parts.day} ${parts.hour}:${parts.minute}`;
@@ -6038,6 +6055,9 @@ function ensureRelayGuessSuffix(label, summary) {
   }
 
   function updateAppInfo(info) {
+    if (info?.timeZone) {
+      setActiveTimeZone(info.timeZone);
+    }
     if (!appVersionLabel) return;
     const version =
       typeof info?.version === 'string' && info.version.trim()


### PR DESCRIPTION
# PR：固定 UI 顯示為台灣時區

## 變更摘要
- 新增統一時間格式化 helper，固定 `Asia/Taipei`
- Mapping Flow、遙測、節點與 tooltip 等顯示改用固定時區
- Web 與 Electron 顯示時間一致
- 支援 `TMAG_TIMEZONE` 覆寫（Docker Compose 已加入範例）

## 變更檔案
- `src/web/public/main.js`
- `src/electron/renderer.js`
- `src/web/server.js`
- `src/electron/main.js`
- `docker-compose.yml`

## 測試
- 未執行（僅前端時間格式化調整）
