### PR TITLE
Update Node.js version to 22 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM node:20-bookworm-slim AS base
+FROM node:22-bookworm-slim AS base
 
 ENV NODE_ENV=production \
     TMAG_WEB_PORT=7080 \


### PR DESCRIPTION
The old version of Node.js is incompatible with the current configuration.